### PR TITLE
[nit] Move cnt definition to the branch it's used in.

### DIFF
--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -43,13 +43,13 @@ where
     if count == 0 {
       Ok(((input, bit_offset), 0u8.into()))
     } else {
-      let cnt = (count + bit_offset).div(8);
       if input.input_len() * 8 < count + bit_offset {
         Err(Err::Error(E::from_error_kind(
           (input, bit_offset),
           ErrorKind::Eof,
         )))
       } else {
+        let cnt = (count + bit_offset).div(8);
         let mut acc: O = 0_u8.into();
         let mut offset: usize = bit_offset;
         let mut remaining: usize = count;


### PR DESCRIPTION
It's not a big deal and compiler should be able to do this automatically, but this also reduces the scope of the definition.